### PR TITLE
Add build scripts and regenerate sprite docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install
 npm run build
 ```
 
-This invokes `gulp` to recreate the PNG and SVG sprites under the `sprites` directory.
+The `prepare` hook runs this command automatically after installing dependencies, so `npm install` will usually regenerate the files for you. This invokes `gulp` to recreate the PNG and SVG sprites under the `sprites` directory.
 
 ## Polymer icons
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Read more in the [font portion](https://google.github.io/material-design-icons/#
 
 The `css-sprite` and `svg-sprite` folders contain pre-generated sprite sheets, as well as svg symbols that can be `<use>`d more directly and with fewer constraints. Instructions for using them are in the [sprites documentation](https://github.com/google/material-design-icons/tree/master/sprites).
 
+### Regenerating sprites
+
+If you modify the source icons, install dependencies and run the build script to update the sprite sheets:
+
+```bash
+npm install
+npm run build
+```
+
+This invokes `gulp` to recreate the PNG and SVG sprites under the `sprites` directory.
+
 ## Polymer icons
 
 If you wish to use the icon set with Polymer, we recommend consuming them via the [`<iron-icons>`](https://github.com/polymerelements/iron-icons) element ([`<core-icons>`](https://github.com/Polymer/core-icons) in v0.5).

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "url": "https://github.com/google/material-design-icons/issues"
   },
   "homepage": "https://github.com/google/material-design-icons",
+  "scripts": {
+    "build": "gulp",
+    "prepare": "npm run build"
+  },
   "devDependencies": {
     "babel-core": "^6.1.2",
     "babel-preset-es2015": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/google/material-design-icons",
   "scripts": {
-    "build": "gulp",
+    "build": "npx gulp",
     "prepare": "npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `build` and `prepare` scripts for gulp
- explain how to rebuild sprites in README

## Testing
- `npm run build` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_686262c81d148328afec4f4e35d7bd88